### PR TITLE
Add support for getting namespaced translations

### DIFF
--- a/config/fluent.php
+++ b/config/fluent.php
@@ -17,4 +17,10 @@ return [
      */
     'use_isolating' => false,
 
+    /*
+     * Determines if namespaced translations should be overridable in the
+     * standard Laravel manner of creating a `lang/vendor` directory.
+     */
+    'allow_overrides' => true,
+
 ];

--- a/src/FluentServiceProvider.php
+++ b/src/FluentServiceProvider.php
@@ -50,7 +50,8 @@ final class FluentServiceProvider extends ServiceProvider
             assert(
                 is_array($options)
                 && is_bool($options['strict'])
-                && is_bool($options['use_isolating']),
+                && is_bool($options['use_isolating'])
+                && is_bool($options['allow_overrides']),
             );
 
             return new FluentTranslator(
@@ -62,6 +63,7 @@ final class FluentServiceProvider extends ServiceProvider
                 bundleOptions: [
                     'strict' => $options['strict'],
                     'useIsolating' => $options['use_isolating'],
+                    'allowOverrides' => $options['allow_overrides'],
                 ],
             );
         });

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Major\Fluent\Laravel\Tests;
+
+final class NamespaceTest extends TestCase
+{
+    /**
+     * @testdox it can get namespaced translations
+     */
+    public function testNamespace(): void
+    {
+        $this->app['translator']->addNamespace('namespace', __DIR__.'/namespace');
+
+        $this->assertSame(
+            'In namespaced PL bundle.',
+            __('namespace::test.in-namespaced-locale-bundle'),
+        );
+    }
+
+    /**
+     * @testdox it allows namespaced translations to be overridden
+     */
+    public function testOverride(): void
+    {
+        $this->app['translator']->addNamespace('override', __DIR__.'/namespace');
+
+        $this->assertSame(
+            'Override of namespaced PL bundle.',
+            __('override::test.in-namespaced-locale-bundle'),
+        );
+    }
+}

--- a/tests/lang/vendor/override/pl/test.ftl
+++ b/tests/lang/vendor/override/pl/test.ftl
@@ -1,0 +1,1 @@
+in-namespaced-locale-bundle = Override of namespaced PL bundle.

--- a/tests/namespace/pl/test.ftl
+++ b/tests/namespace/pl/test.ftl
@@ -1,0 +1,1 @@
+in-namespaced-locale-bundle = In namespaced PL bundle.


### PR DESCRIPTION
This PR adds support for loading translations from namespaced .ftl files, as in `namespace::some.message`. This is useful for Laravel package developers that wish to use Fluent for their package translations.

```
# namespace/en/some.ftl
message = Hello, world!
```

```php
$this->app['translator']->addNamespace('namespace', __DIR__.'/namespace');

__('namespace::some.message'); // Hello, world!
```

## Overrides
There is a new `allow_overrides` config option which corresponds to the `allowOverrides` option for `FluentBundle`. If enabled, it allows namespaced translations to be overridden by package consumers in the standard Laravel manner of creating a `lang/vendor/{namespace}/{locale}/{group}.ftl` file, which will be appended to the `FluentBundle`.

A point for review is whether this option should be enabled by default.

## Stability
Much of the code added in `FluentTranslator` is adapted from Laravel's `FileLoader` class, so it should be pretty solid. The tests I've added are far from comprehensive, but at least prove the basic functionality works.