### PR TITLE
config: check env directly

### DIFF
--- a/config/fluent.php
+++ b/config/fluent.php
@@ -8,7 +8,7 @@ return [
      * It's recommended to enable this setting in development
      * to make it easy to spot mistakes.
      */
-    'strict' => ! app()->isProduction(),
+    'strict' => env('APP_ENV', 'production') !== 'production',
 
     /*
      * Determines if it should use Unicode isolation marks (FSI, PDI)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,11 +3,6 @@ parameters:
     paths:
         - config
         - src
-    ignoreErrors:
-        -
-            message: '#^Cannot call method isProduction\(\) on mixed\.$#'
-            count: 1
-            path: config/fluent.php
     tmpDir: .cache/phpstan
 
 includes:

--- a/tests/ServiceTest.php
+++ b/tests/ServiceTest.php
@@ -17,6 +17,7 @@ final class ServiceTest extends TestCase
     {
         $path = app('path.lang');
         $locales = app('config')->getMany(['app.locale', 'app.fallback_locale']);
+        $fluent = app('config')->get('fluent');
 
         $this->assertSame(__DIR__ . '/lang', $path);
 
@@ -24,6 +25,11 @@ final class ServiceTest extends TestCase
             'app.locale' => 'pl',
             'app.fallback_locale' => 'en',
         ], $locales);
+
+        $this->assertSame([
+            'strict' => true,
+            'use_isolating' => false,
+        ], $fluent);
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,7 @@ abstract class TestCase extends OrchestraTestCase
         $app['config']->set([
             'app.locale' => 'pl',
             'app.fallback_locale' => 'en',
+            'fluent.strict' => true,
         ]);
 
         parent::resolveApplicationBootstrappers($app);


### PR DESCRIPTION
Usage of `app()->inProduction()` yields an exception:

> laravel.ERROR: Target class [env] does not exist. {"exception":"[object] (Illuminate\\Contracts\\Container\\BindingResolutionException(code: 0): Target class [env] does not exist.

Checking the environment directly, using the sensible default as used in the application skeleton config, solves the problem.